### PR TITLE
Set socket.js content type to text/javascript.

### DIFF
--- a/brolink/brolink.js
+++ b/brolink/brolink.js
@@ -40,6 +40,7 @@ var server = http.createServer(function(request, response) {
                 if (err) {
                     console.log(err);
                 }
+				response.setHeader('content-type', 'text/javascript');
 				response.writeHead(200);
 				response.write(data);
 				response.end();


### PR DESCRIPTION
Otherwise Chrome doesn't load socket.js and says:
_Resource interpreted as script but transferred with MIME type text/plain._
