### PR TITLE
Added manual call to plugin and automatically open html file in browser

### DIFF
--- a/plugin/brolink.vim
+++ b/plugin/brolink.vim
@@ -128,14 +128,23 @@ if !exists("g:bl_no_mappings")
 endif
 
 function! s:Start()
-	if !exists("g:bl_no_autoupdate")
-		call s:setupHandlers()
-	endif
-	call s:Connect()
+  if !exists("g:bl_no_autoupdate")
+    if has('mac')
+      silent !open '%:p'
+      redraw!
+    endif
+    if has('win32')
+      silent !cmd 'start %:p'
+      redraw!
+    endif
+  call s:setupHandlers()
+  endif
+  au VimLeave * :BLDisconnect
+  call s:Connect()
 endfunction
 
 if !exists("g:bl_no_implystart")
-	call s:Start()
+    call s:Start()
 endif
 
-au VimLeave * :BLDisconnect
+command Brolink call <SID>Start()


### PR DESCRIPTION
As per my comments in _issues_. Would be nice to find a way to "automagically" start node brolink and exit on leave as well but can only hack this solution together using !brolink.sh and !killall -f brolink. If the node app had an exit command implemented then we could kill it with a URL call.
