### PR TITLE
Add new variable g:bl_state to control connect and disconnect

### DIFF
--- a/plugin/brolink.vim
+++ b/plugin/brolink.vim
@@ -18,6 +18,8 @@ if !exists("g:bl_serverpath")
 	let g:bl_serverpath = "http://127.0.0.1:9001"
 endif
 
+let g:bl_state = 0
+
 python <<NOMAS
 import sys
 import threading
@@ -87,11 +89,17 @@ function! s:ReloadCSS()
 endfunction
 
 function! s:Disconnect()
-	python disconnect()
+    if(g:bl_state == 1)
+	    python disconnect()
+	    let g:bl_state = 0
+	endif
 endfunction
 
 function! s:Connect()
-	python startbrolink()
+    if(g:bl_state == 0)
+	    python startbrolink()
+	    let g:bl_state = 1
+	endif
 endfunction
 
 function! s:get_visual_selection()


### PR DESCRIPTION
I just add a new variable `g:bl_state` to represent connect and disconnect state. It should work with `g:bl_no_implystart` and fixed this issue https://github.com/jaxbot/brolink.vim/issues/2#issuecomment-27275486
