### PR TITLE
Only reload visible tabs/pages.

### DIFF
--- a/brolink/js/socket.js
+++ b/brolink/js/socket.js
@@ -9,6 +9,46 @@
 	// Change port/address if needed 
 	var socket = new WebSocket("ws://127.0.0.1:9001/");
 
+	// Function to handle visible/non-visible. From http://stackoverflow.com/a/19519701
+	var visible = (function(){
+		// Determine the state and event keys.
+		var stateKey, eventKey, keys = {
+			hidden: "visibilitychange",
+			webkitHidden: "webkitvisibilitychange",
+			mozHidden: "mozvisibilitychange",
+			msHidden: "msvisibilitychange"
+		};
+		for (stateKey in keys) {
+			if (stateKey in document) {
+				eventKey = keys[stateKey];
+				break;
+			}
+		}
+
+		// Build the function using this key.
+		vis = function(cb) {
+			// If one is given, register a callback.
+			if (cb) {
+				document.addEventListener(eventKey, function() {
+					cb(vis()); 
+				});
+			}
+
+			// Return the current state.
+			return !document[stateKey];
+		}
+		return vis;
+	})();
+
+	// Listen for window visible and non-visible.
+	var pendingReload = false;
+	visible(function(vis) {
+		if (vis && pendingReload) {
+			window.location.reload();
+			pendingReload = false;
+		}
+	});
+
 	socket.onopen = function(evt) {  };
 	socket.onclose = function(evt) {  };
 	socket.onmessage = function(evt) { 
@@ -17,7 +57,11 @@
 				reloadCSS();
 			break;
 			case "page":
-				window.location.reload();
+				if (visible()) {
+					window.location.reload();
+				} else {
+					pendingReload = true;
+				}
 			break;
 			default:
 				console.log(evt.data);


### PR DESCRIPTION
This so that hidden tabs/windows will not be reloaded needlessly. This uses the visibility API, so a non-focused but still visible page will be reloaded as expected. Additionally, pages do remember their pending reloads, so when you switch to a tab/page that should have been reloaded it will do so immediately.
