### PR TITLE
fix typo for win32

### DIFF
--- a/autoload/browserlink.vim
+++ b/autoload/browserlink.vim
@@ -37,7 +37,7 @@ endfunction
 function! browserlink#startBrowserlink()
 	if has("win32")
 		execute 'cd' fnameescape(s:path . "/browserlink")
-		call system("./start.bat")
+		call system("start.bat")
 		execute 'cd -'
 	else
 		execute 'cd' fnameescape(s:path . "/browserlink")


### PR DESCRIPTION
The plugin didn't work for windows until I removed this.
Since the script already changes the present working directory to the appropriate folder, the './' isn't necessary anyway.