### PR TITLE
Added an option to not reload css files

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ This function can be easily tweaked to fit your needs/workflow, and I highly rec
 
 If set, Browserlink won't try to reload pages/CSS when you save respective files.
 
+`g:bl_no_css_reload`
+
+If set, Browserlink won't reload css files, but it still will reload pages
+with other filetypes like html or javascript (as specified by
+g:bl_pagefiletypes below).
+
 `g:bl_no_eager`
 
 If set, Browserlink won't autostart the server when a command is run and the server does not respond.

--- a/doc/browserlink.txt
+++ b/doc/browserlink.txt
@@ -178,6 +178,12 @@ Options ~
 If set, Browserlink won't try to reload pages/CSS when you save respective
 files.
 
+'g:bl_no_css_reload'
+
+If set, Browserlink won't reload css files, but it still will reload pages
+with other filetypes like html or javascript (as specified by
+g:bl_pagefiletypes below).
+
 'g:bl_no_eager'
 
 If set, Browserlink won't autostart the server when a command is run and the

--- a/plugin/browserlink.vim
+++ b/plugin/browserlink.vim
@@ -48,7 +48,9 @@ endfunction
 
 function! s:setupHandlers()
 	au BufWritePost * call s:autoReload()
-	au BufWritePost *.css :BLReloadCSS
+	if !exists("g:bl_no_css_reload")
+		au BufWritePost *.css :BLReloadCSS
+	endif
 endfunction
 
 if !exists("g:bl_no_autoupdate")


### PR DESCRIPTION
I like to use browserlink to reload the browser on html file change, but leave reloading css files to chrome devtools.
The reason for that is that chrome is able to reload only necessary css changes, while this plugin reloads all css files which takes much longer.